### PR TITLE
Added TestDataGenerator and tests

### DIFF
--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -149,7 +148,7 @@ public class AdminServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
-    throws IOException, ServletException {
+      throws IOException, ServletException {
 
     String user = (String) request.getSession().getAttribute("user");
 
@@ -162,5 +161,27 @@ public class AdminServlet extends HttpServlet {
 
   }
 
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException{
+
+    String user = (String) request.getSession().getAttribute("user");
+
+    if (admins.contains(user)) {
+      TestDataGenerator generator = TestDataGenerator.getInstance();
+      int numUsers = Integer.parseInt(request.getParameter("numUsers"));
+      int numConvos = Integer.parseInt(request.getParameter("numConvos"));
+      int numMessages = Integer.parseInt(request.getParameter("numMessages"));
+
+      generator.addTestUsers(numUsers);
+      generator.addTestConversations(numConvos);
+      generator.addTestMessages(numMessages);
+
+      computeAdminStats(request);
+      request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
+    } else {
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+  }
 
 }

--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -24,8 +24,6 @@ import codeu.model.store.persistence.PersistentStorageAgent;
 
 public class AdminServlet extends HttpServlet {
 
-  private HashSet<String> admins;
-
   private UserStore userStore;
   private ConversationStore conversationStore;
   private MessageStore messageStore;
@@ -34,22 +32,10 @@ public class AdminServlet extends HttpServlet {
   public void init() throws ServletException {
     super.init();
 
-    setAdminUsernames();
-
     setUserStore(UserStore.getInstance());
     setConversationStore(ConversationStore.getInstance());
     setMessageStore(MessageStore.getInstance());
 
-  }
-
-  void setAdminUsernames() {
-    admins = new HashSet<String>();
-    admins.add("admin");
-    admins.add("daniel");
-    admins.add("leslie");
-    admins.add("serena");
-    admins.add("shana");
-    admins.add("kyra");
   }
 
   void setUserStore(UserStore userStore) {
@@ -152,9 +138,7 @@ public class AdminServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
 
-    String user = (String) request.getSession().getAttribute("user");
-
-    if (admins.contains(user)) {
+    if (request.getSession().getAttribute("isAdmin").equals(Boolean.TRUE)) {
       computeAdminStats(request);
       request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
     } else {
@@ -167,9 +151,8 @@ public class AdminServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException{
 
-    String user = (String) request.getSession().getAttribute("user");
 
-    if (admins.contains(user)) {
+    if (request.getSession().getAttribute("isAdmin").equals(Boolean.TRUE)) {
       switch (request.getParameter("id")) {
         case "dataGenOptions":
 

--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -19,6 +19,8 @@ import codeu.model.data.User;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.persistence.PersistentDataStoreException;
+import codeu.model.store.persistence.PersistentStorageAgent;
 
 public class AdminServlet extends HttpServlet {
 
@@ -168,15 +170,19 @@ public class AdminServlet extends HttpServlet {
     String user = (String) request.getSession().getAttribute("user");
 
     if (admins.contains(user)) {
-      TestDataGenerator generator = TestDataGenerator.getInstance();
-      int numUsers = Integer.parseInt(request.getParameter("numUsers"));
-      int numConvos = Integer.parseInt(request.getParameter("numConvos"));
-      int numMessages = Integer.parseInt(request.getParameter("numMessages"));
+      switch (request.getParameter("id")) {
+        case "dataGenOptions":
 
-      generator.addTestUsers(numUsers);
-      generator.addTestConversations(numConvos);
-      generator.addTestMessages(numMessages);
-
+          addTestData(parseInt(request.getParameter("numUsers")),
+              parseInt(request.getParameter("numConvos")),
+              parseInt(request.getParameter("numMessages")));
+          break;
+        case "clearTestData":
+          clearTestData();
+          break;
+        default:
+          break;
+      }
       computeAdminStats(request);
       request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
     } else {
@@ -184,4 +190,23 @@ public class AdminServlet extends HttpServlet {
     }
   }
 
+  private int parseInt(String str) {
+    try {
+      return Integer.parseInt(str);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  void addTestData(int numUsers, int numConvos, int numMessages) {
+    TestDataGenerator generator = TestDataGenerator.getInstance();
+
+    generator.addTestUsers(numUsers);
+    generator.addTestConversations(numConvos);
+    generator.addTestMessages(numMessages);
+  }
+
+  void clearTestData() {
+    TestDataGenerator.getInstance().clearTestData();
+  }
 }

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -137,9 +137,16 @@ public class ChatServlet extends HttpServlet {
 		String conversationTitle = requestUrl.substring("/chat/".length());
 
 		Conversation conversation = conversationStore.getConversationWithTitle(conversationTitle);
+
 		if (conversation == null) {
 			// couldn't find conversation, redirect to conversation list
 			response.sendRedirect("/conversations");
+			return;
+		}
+
+		if (TestDataGenerator.getInstance().isTestConversation(conversation.getId())) {
+			// No user may contribute to a test conversation
+			response.sendRedirect("/chat/" + conversationTitle);
 			return;
 		}
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -74,7 +74,6 @@ public class ConversationServlet extends HttpServlet {
     List<Conversation> conversations = conversationStore.getAllConversations();
 
     // Filter out test data to non-admins
-
     HttpSession session = request.getSession();
     boolean adminStatus = session.getAttribute("isAdmin") != null ? (boolean) session.getAttribute("isAdmin") : false;
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /** Servlet class responsible for the conversations page. */
 public class ConversationServlet extends HttpServlet {
@@ -71,6 +72,21 @@ public class ConversationServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
     List<Conversation> conversations = conversationStore.getAllConversations();
+
+    // Filter out test data to non-admins
+
+    HttpSession session = request.getSession();
+    boolean adminStatus = session.getAttribute("isAdmin") != null ? (boolean) session.getAttribute("isAdmin") : false;
+
+    if (adminStatus == false) {
+      TestDataGenerator tdg = TestDataGenerator.getInstance();
+      for (int i = conversations.size() - 1; i >= 0; i--) {
+        if (tdg.isTestConversation(conversations.get(i).getId())) {
+          conversations.remove(i);
+        }
+      }
+    }
+
     request.setAttribute("conversations", conversations);
     request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
   }

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -14,15 +14,17 @@
 
 package codeu.controller;
 
-import codeu.model.data.User;
-import codeu.model.store.basic.UserStore;
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.mindrot.jbcrypt.BCrypt;
+
+import codeu.model.data.User;
+import codeu.model.store.basic.UserStore;
 
 /** Servlet class responsible for the login page. */
 public class LoginServlet extends HttpServlet {
@@ -84,6 +86,7 @@ public class LoginServlet extends HttpServlet {
     }
 
     request.getSession().setAttribute("user", username);
+    request.getSession().setAttribute("isAdmin", user.isAdmin());
     response.sendRedirect("/conversations");
   }
 }

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -1,5 +1,14 @@
 package codeu.controller;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.mindrot.jbcrypt.BCrypt;
+
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
@@ -8,9 +17,6 @@ import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
 import codeu.model.store.persistence.PersistentDataStoreException;
 import codeu.model.store.persistence.PersistentStorageAgent;
-import java.util.List;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
 
 /**
  * Listener class that fires when the server first starts up, before any servlet classes are
@@ -23,6 +29,13 @@ public class ServerStartupListener implements ServletContextListener {
   public void contextInitialized(ServletContextEvent sce) {
     try {
       List<User> users = PersistentStorageAgent.getInstance().loadUsers();
+      
+      String adminPassword = "admin";
+      String hashedPassword = BCrypt.hashpw(adminPassword, BCrypt.gensalt());
+      User rootAdmin = new User(UUID.randomUUID(), "admin", hashedPassword, Instant.ofEpochSecond(0));
+      rootAdmin.setAdminStatus(true);
+      users.add(rootAdmin);
+
       UserStore.getInstance().setUsers(users);
 
       List<Conversation> conversations = PersistentStorageAgent.getInstance().loadConversations();

--- a/src/main/java/codeu/controller/TestDataGenerator.java
+++ b/src/main/java/codeu/controller/TestDataGenerator.java
@@ -29,18 +29,18 @@ class TestDataGenerator {
   private ConversationStore conversationStore;
   private MessageStore messageStore;
 
-  private List<UUID> testUsers;
-  private List<UUID> testConversations;
-  private List<UUID> testMessages;
+  private List<User> testUsers;
+  private List<Conversation> testConversations;
+  private List<Message> testMessages;
 
   private TestDataGenerator() {
     setUserStore(UserStore.getInstance());
     setConversationStore(ConversationStore.getInstance());
     setMessageStore(MessageStore.getInstance());
 
-    testUsers = new ArrayList<UUID>();
-    testConversations = new ArrayList<UUID>();
-    testMessages = new ArrayList<UUID>();
+    testUsers = new ArrayList<User>();
+    testConversations = new ArrayList<Conversation>();
+    testMessages = new ArrayList<Message>();
   }
 
   void setUserStore(UserStore userStore) {
@@ -83,24 +83,34 @@ class TestDataGenerator {
           Instant.ofEpochSecond(ThreadLocalRandom.current().nextInt(1, 10001)));
 
       userStore.addUser(newUser);
-      testUsers.add(newUser.getId());
+      testUsers.add(newUser);
     }
   }
 
   public void addTestConversations(int numberOfConversations) {
+    if (testUsers.size() == 0) {
+      System.out.println("Unable to create test conversations. Please create test users first.");
+      return;
+    }
+
     Conversation newConversation;
     User owner;
     for (int i = 0; i < numberOfConversations; i++) {
-      owner = userStore.getAllUsers().get(ThreadLocalRandom.current().nextInt(0, userStore.getAllUsers().size()));
+      owner = testUsers.get(ThreadLocalRandom.current().nextInt(0, testUsers.size()));
       newConversation = new Conversation(UUID.randomUUID(), owner.getId(), "conversation"+testConversations.size(),
           Instant.now());
 
       conversationStore.addConversation(newConversation);
-      testConversations.add(newConversation.getId());
+      testConversations.add(newConversation);
     }
   }
 
   public void addTestMessages(int numberOfMessages) {
+    if (testConversations.size() == 0) {
+      System.out.println("Unable to create test messages. Please create test conversations first.");
+      return;
+    }
+
     Message newMessage;
     Conversation conversation;
     User author;
@@ -121,6 +131,7 @@ class TestDataGenerator {
           content, Instant.now());
 
       messageStore.addMessage(newMessage);
+      testMessages.add(newMessage);
     }
   }
 }

--- a/src/main/java/codeu/controller/TestDataGenerator.java
+++ b/src/main/java/codeu/controller/TestDataGenerator.java
@@ -1,0 +1,81 @@
+package codeu.controller;
+
+class TestDataGenerator {
+
+  private TestDataGenerator instance;
+
+  public static TestDataGenerator getInstance() {
+    if (instance == null) {
+      instance = new TestDataGenerator();
+    }
+
+    return instance;
+  }
+
+  private UserStore userStore;
+  private ConversationStore conversationStore;
+  private MessageStore messageStore;
+
+  private TestDataGenerator() {
+    setUserStore(UserStore.getTestInstance());
+    setConversationStore(ConversationStore.getTestInstance());
+    setMessageStore(MessageStore.getTestInstance());
+  }
+
+  void setUserStore(UserStore userStore) {
+    this.userStore = userStore;
+  }
+  void setConversationStore(ConversationStore conversationStore) {
+    this.conversationStore = conversationStore;
+  }
+  void setMessageStore(MessageStore messageStore) {
+    this.messageStore = messageStore;
+  }
+
+  void addTestData() {
+    int numberOfUsers = ThreadLocalRandom.current().nextInt(10, 101);
+    int numberOfConversations = ThreadLocalRandom.current().nextInt(5, 21);
+    int numberOfMessages = ThreadLocalRandom.current().nextInt(100, 1001);
+
+    User newUser;
+    for (int i = 0; i < numberOfUsers; i++) {
+      newUser = new User(UUID.randomUUID(), "user"+i, "password",
+          Instant.ofEpochSecond(ThreadLocalRandom.current().nextInt(1, 10001)));
+
+      userStore.addUser(newUser);
+    }
+
+    Conversation newConversation;
+    User owner;
+    for (int i = 0; i < numberOfConversations; i++) {
+      owner = userStore.getAllUsers().get(ThreadLocalRandom.current().nextInt(0, userStore.getAllUsers().size()));
+      newConversation = new Conversation(UUID.randomUUID(), owner.getId(), "conversation"+i,
+          Instant.now());
+
+      conversationStore.addConversation(newConversation);
+    }
+
+    Message newMessage;
+    Conversation conversation;
+    User author;
+    int numberOfWords;
+    String content;
+    for (int i = 0; i < numberOfMessages; i++) {
+      author = userStore.getAllUsers().get(ThreadLocalRandom.current().nextInt(0, userStore.getAllUsers().size()));
+      conversation = conversationStore.getAllConversations().get(ThreadLocalRandom.current().
+          nextInt(0, conversationStore.getAllConversations().size()));
+
+      numberOfWords = ThreadLocalRandom.current().nextInt(0, 21);
+      content = "" + (char) ThreadLocalRandom.current().nextInt('a', 'z'+1);
+      for (int w = 1; w < numberOfWords; w++) {
+        content += " " + (char) ThreadLocalRandom.current().nextInt('a', 'z'+1);
+      }
+
+      newMessage = new Message(UUID.randomUUID(), conversation.getId(), author.getId(),
+          content, Instant.now());
+
+      messageStore.addMessage(newMessage);
+    }
+  }
+
+}

--- a/src/main/java/codeu/controller/TestDataGenerator.java
+++ b/src/main/java/codeu/controller/TestDataGenerator.java
@@ -1,8 +1,21 @@
 package codeu.controller;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.store.basic.UserStore;
+
 class TestDataGenerator {
 
-  private TestDataGenerator instance;
+  private static TestDataGenerator instance;
 
   public static TestDataGenerator getInstance() {
     if (instance == null) {
@@ -16,20 +29,39 @@ class TestDataGenerator {
   private ConversationStore conversationStore;
   private MessageStore messageStore;
 
+  private List<UUID> testUsers;
+  private List<UUID> testConversations;
+  private List<UUID> testMessages;
+
   private TestDataGenerator() {
-    setUserStore(UserStore.getTestInstance());
-    setConversationStore(ConversationStore.getTestInstance());
-    setMessageStore(MessageStore.getTestInstance());
+    setUserStore(UserStore.getInstance());
+    setConversationStore(ConversationStore.getInstance());
+    setMessageStore(MessageStore.getInstance());
+
+    testUsers = new ArrayList<UUID>();
+    testConversations = new ArrayList<UUID>();
+    testMessages = new ArrayList<UUID>();
   }
 
   void setUserStore(UserStore userStore) {
     this.userStore = userStore;
   }
+  public UserStore getUserStore() {
+    return userStore;
+  }
+
   void setConversationStore(ConversationStore conversationStore) {
     this.conversationStore = conversationStore;
   }
+  public ConversationStore getConversationStore() {
+    return conversationStore;
+  }
+
   void setMessageStore(MessageStore messageStore) {
     this.messageStore = messageStore;
+  }
+  public MessageStore getMessageStore() {
+    return messageStore;
   }
 
   void addTestData() {
@@ -37,24 +69,38 @@ class TestDataGenerator {
     int numberOfConversations = ThreadLocalRandom.current().nextInt(5, 21);
     int numberOfMessages = ThreadLocalRandom.current().nextInt(100, 1001);
 
+    addTestUsers(numberOfUsers);
+
+    addTestConversations(numberOfConversations);
+
+    addTestMessages(numberOfMessages);
+  }
+
+  public void addTestUsers(int numberOfUsers) {
     User newUser;
     for (int i = 0; i < numberOfUsers; i++) {
-      newUser = new User(UUID.randomUUID(), "user"+i, "password",
+      newUser = new User(UUID.randomUUID(), "user"+testUsers.size(), "password",
           Instant.ofEpochSecond(ThreadLocalRandom.current().nextInt(1, 10001)));
 
       userStore.addUser(newUser);
+      testUsers.add(newUser.getId());
     }
+  }
 
+  public void addTestConversations(int numberOfConversations) {
     Conversation newConversation;
     User owner;
     for (int i = 0; i < numberOfConversations; i++) {
       owner = userStore.getAllUsers().get(ThreadLocalRandom.current().nextInt(0, userStore.getAllUsers().size()));
-      newConversation = new Conversation(UUID.randomUUID(), owner.getId(), "conversation"+i,
+      newConversation = new Conversation(UUID.randomUUID(), owner.getId(), "conversation"+testConversations.size(),
           Instant.now());
 
       conversationStore.addConversation(newConversation);
+      testConversations.add(newConversation.getId());
     }
+  }
 
+  public void addTestMessages(int numberOfMessages) {
     Message newMessage;
     Conversation conversation;
     User author;
@@ -77,5 +123,4 @@ class TestDataGenerator {
       messageStore.addMessage(newMessage);
     }
   }
-
 }

--- a/src/main/java/codeu/controller/TestDataGenerator.java
+++ b/src/main/java/codeu/controller/TestDataGenerator.java
@@ -2,6 +2,7 @@ package codeu.controller;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -42,12 +43,16 @@ class TestDataGenerator {
   private List<Conversation> testConversations;
   private List<Message> testMessages;
 
+  private HashSet<UUID> testConversationIds;
+
   private TestDataGenerator(PersistentStorageAgent persistentStorageAgent) {
     this.persistentStorageAgent = persistentStorageAgent;
 
     testUsers = new ArrayList<User>();
     testConversations = new ArrayList<Conversation>();
     testMessages = new ArrayList<Message>();
+
+    testConversationIds = new HashSet<UUID>();
   }
 
   private void init() {
@@ -77,19 +82,8 @@ class TestDataGenerator {
     return messageStore;
   }
 
-  void addTestData() {
-    int numberOfUsers = ThreadLocalRandom.current().nextInt(10, 101);
-    int numberOfConversations = ThreadLocalRandom.current().nextInt(5, 21);
-    int numberOfMessages = ThreadLocalRandom.current().nextInt(100, 1001);
-
-    addTestUsers(numberOfUsers);
-
-    addTestConversations(numberOfConversations);
-
-    addTestMessages(numberOfMessages);
-  }
-
   public void addTestUsers(int numberOfUsers) {
+    System.out.println("Adding " + numberOfUsers + " test users");
     User newUser;
     for (int i = 0; i < numberOfUsers; i++) {
       newUser = new User(UUID.randomUUID(), "user"+testUsers.size(), "password",
@@ -105,6 +99,7 @@ class TestDataGenerator {
       System.out.println("Unable to create test conversations. Please create test users first.");
       return;
     }
+    System.out.println("Adding " + numberOfConversations + " test conversations");
 
     Conversation newConversation;
     User owner;
@@ -115,6 +110,7 @@ class TestDataGenerator {
 
       conversationStore.addVolatileConversation(newConversation);
       testConversations.add(newConversation);
+      testConversationIds.add(newConversation.getId());
     }
   }
 
@@ -123,6 +119,7 @@ class TestDataGenerator {
       System.out.println("Unable to create test messages. Please create test conversations first.");
       return;
     }
+    System.out.println("Adding " + numberOfMessages + " test messages");
 
     Message newMessage;
     Conversation conversation;
@@ -130,9 +127,9 @@ class TestDataGenerator {
     int numberOfWords;
     String content;
     for (int i = 0; i < numberOfMessages; i++) {
-      author = testUsers.get(ThreadLocalRandom.current().nextInt(0, userStore.getAllUsers().size()));
-      conversation = conversationStore.getAllConversations().get(ThreadLocalRandom.current().
-          nextInt(0, conversationStore.getAllConversations().size()));
+      author = testUsers.get(ThreadLocalRandom.current().nextInt(0, testUsers.size()));
+      conversation = testConversations.get(ThreadLocalRandom.current().
+          nextInt(0, testConversations.size()));
 
       numberOfWords = ThreadLocalRandom.current().nextInt(0, 21);
       content = "" + (char) ThreadLocalRandom.current().nextInt('a', 'z'+1);
@@ -156,5 +153,9 @@ class TestDataGenerator {
     } catch(PersistentDataStoreException e) {
       e.printStackTrace();
     }
+  }
+
+  public boolean isTestConversation(UUID id) {
+    return testConversationIds.contains(id);
   }
 }

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -24,6 +24,8 @@ public class User {
   private final String passwordHash;
   private final Instant creation;
 
+  private boolean isAdmin;
+
   /**
    * Constructs a new User.
    *
@@ -37,6 +39,8 @@ public class User {
     this.name = name;
     this.passwordHash = passwordHash;
     this.creation = creation;
+
+    this.isAdmin = false;
   }
 
   /** Returns the ID of this User. */
@@ -48,7 +52,7 @@ public class User {
   public String getName() {
     return name;
   }
-  
+
   /** Returns the password hash of this User. */
   public String getPasswordHash() {
     return passwordHash;
@@ -57,5 +61,13 @@ public class User {
   /** Returns the creation time of this User. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  public void setAdminStatus(boolean status) {
+    isAdmin = status;
+  }
+
+  public boolean isAdmin() {
+    return isAdmin;
   }
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -14,10 +14,13 @@
 
 package codeu.model.store.basic;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
 import codeu.model.data.Conversation;
 import codeu.model.store.persistence.PersistentStorageAgent;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Store class that uses in-memory data structures to hold values and automatically loads from and
@@ -75,6 +78,10 @@ public class ConversationStore {
     persistentStorageAgent.writeThrough(conversation);
   }
 
+  public void addVolatileConversation(Conversation conversation) {
+    conversations.add(conversation);
+  }
+
   /** Check whether a Conversation title is already known to the application. */
   public boolean isTitleTaken(String title) {
     // This approach will be pretty slow if we have many Conversations.
@@ -99,5 +106,35 @@ public class ConversationStore {
   /** Sets the List of Conversations stored by this ConversationStore. */
   public void setConversations(List<Conversation> conversations) {
     this.conversations = conversations;
+  }
+
+  public void deleteConversation(Conversation conversation) {
+
+    for (int i = 0; i < conversations.size(); i++) {
+      if (conversations.get(i) == conversation) {
+        conversations.remove(i);
+        return;
+      }
+    }
+
+    persistentStorageAgent.deleteEntity(conversation.getId());
+  }
+
+  public void deleteConversations(List<Conversation> conversations) {
+    List<UUID> ids = new ArrayList<UUID>();
+    HashSet<Conversation> conversationSet = new HashSet<Conversation>();
+    for (Conversation c : conversations) {
+      ids.add(c.getId());
+      conversationSet.add(c);
+    }
+
+    for (int i = conversations.size() - 1; i >= 0; i--) {
+      if (conversationSet.contains(conversations.get(i))) {
+        conversations.remove(i);
+      }
+    }
+
+    persistentStorageAgent.deleteEntities(ids);
+
   }
 }

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -108,33 +108,5 @@ public class ConversationStore {
     this.conversations = conversations;
   }
 
-  public void deleteConversation(Conversation conversation) {
 
-    for (int i = 0; i < conversations.size(); i++) {
-      if (conversations.get(i) == conversation) {
-        conversations.remove(i);
-        return;
-      }
-    }
-
-    persistentStorageAgent.deleteEntity(conversation.getId());
-  }
-
-  public void deleteConversations(List<Conversation> conversations) {
-    List<UUID> ids = new ArrayList<UUID>();
-    HashSet<Conversation> conversationSet = new HashSet<Conversation>();
-    for (Conversation c : conversations) {
-      ids.add(c.getId());
-      conversationSet.add(c);
-    }
-
-    for (int i = conversations.size() - 1; i >= 0; i--) {
-      if (conversationSet.contains(conversations.get(i))) {
-        conversations.remove(i);
-      }
-    }
-
-    persistentStorageAgent.deleteEntities(ids);
-
-  }
 }

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -100,32 +100,4 @@ public class MessageStore {
     this.messages = messages;
   }
 
-  public void deleteMessage(Message message) {
-
-    for (int i = 0; i < messages.size(); i++) {
-      if (messages.get(i) == message) {
-        messages.remove(i);
-        return;
-      }
-    }
-
-    persistentStorageAgent.deleteEntity(message.getId());
-  }
-
-  public void deleteMessages(List<Message> messages) {
-    List<UUID> ids = new ArrayList<UUID>();
-    HashSet<Message> messageSet = new HashSet<Message>();
-    for (Message m : messages) {
-      ids.add(m.getId());
-      messageSet.add(m);
-    }
-
-    for (int i = messages.size() - 1; i >= 0; i--) {
-      if (messageSet.contains(messages.get(i))) {
-        messages.remove(i);
-      }
-    }
-
-    persistentStorageAgent.deleteEntities(ids);
-  }
 }

--- a/src/main/java/codeu/model/store/basic/MessageStore.java
+++ b/src/main/java/codeu/model/store/basic/MessageStore.java
@@ -14,11 +14,13 @@
 
 package codeu.model.store.basic;
 
-import codeu.model.data.Message;
-import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+
+import codeu.model.data.Message;
+import codeu.model.store.persistence.PersistentStorageAgent;
 
 /**
  * Store class that uses in-memory data structures to hold values and automatically loads from and
@@ -71,6 +73,10 @@ public class MessageStore {
     persistentStorageAgent.writeThrough(message);
   }
 
+  public void addVolatileMessage(Message message) {
+    messages.add(message);
+  }
+
   /** Access the current set of Messages within the given Conversation. */
   public List<Message> getMessagesInConversation(UUID conversationId) {
 
@@ -85,8 +91,41 @@ public class MessageStore {
     return messagesInConversation;
   }
 
+  public List<Message> getAllMessages() {
+    return messages;
+  }
+
   /** Sets the List of Messages stored by this MessageStore. */
   public void setMessages(List<Message> messages) {
     this.messages = messages;
+  }
+
+  public void deleteMessage(Message message) {
+
+    for (int i = 0; i < messages.size(); i++) {
+      if (messages.get(i) == message) {
+        messages.remove(i);
+        return;
+      }
+    }
+
+    persistentStorageAgent.deleteEntity(message.getId());
+  }
+
+  public void deleteMessages(List<Message> messages) {
+    List<UUID> ids = new ArrayList<UUID>();
+    HashSet<Message> messageSet = new HashSet<Message>();
+    for (Message m : messages) {
+      ids.add(m.getId());
+      messageSet.add(m);
+    }
+
+    for (int i = messages.size() - 1; i >= 0; i--) {
+      if (messageSet.contains(messages.get(i))) {
+        messages.remove(i);
+      }
+    }
+
+    persistentStorageAgent.deleteEntities(ids);
   }
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -137,32 +137,5 @@ public class UserStore {
     this.users = users;
   }
 
-  public void deleteUser(User user) {
-
-    for (int i = 0; i < users.size(); i++) {
-      if (users.get(i) == user) {
-        users.remove(i);
-        return;
-      }
-    }
-
-    persistentStorageAgent.deleteEntity(user.getId());
-  }
-
-  public void deleteUsers(List<User> users) {
-    List<UUID> ids = new ArrayList<UUID>();
-    HashSet<User> userSet = new HashSet<User>();
-    for (User u : users) {
-      ids.add(u.getId());
-      userSet.add(u);
-    }
-
-    for (int i = users.size() - 1; i >= 0; i--) {
-      if (userSet.contains(users.get(i))) {
-        users.remove(i);
-      }
-    }
-
-    persistentStorageAgent.deleteEntities(ids);
-  }
+  
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -14,11 +14,13 @@
 
 package codeu.model.store.basic;
 
-import codeu.model.data.User;
-import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+
+import codeu.model.data.User;
+import codeu.model.store.persistence.PersistentStorageAgent;
 
 /**
  * Store class that uses in-memory data structures to hold values and automatically loads from and
@@ -106,6 +108,10 @@ public class UserStore {
     persistentStorageAgent.writeThrough(user);
   }
 
+  public void addVolatileUser(User user) {
+    users.add(user);
+  }
+
   /**
    * Update an existing User.
    */
@@ -129,5 +135,34 @@ public class UserStore {
    */
   public void setUsers(List<User> users) {
     this.users = users;
+  }
+
+  public void deleteUser(User user) {
+
+    for (int i = 0; i < users.size(); i++) {
+      if (users.get(i) == user) {
+        users.remove(i);
+        return;
+      }
+    }
+
+    persistentStorageAgent.deleteEntity(user.getId());
+  }
+
+  public void deleteUsers(List<User> users) {
+    List<UUID> ids = new ArrayList<UUID>();
+    HashSet<User> userSet = new HashSet<User>();
+    for (User u : users) {
+      ids.add(u.getId());
+      userSet.add(u);
+    }
+
+    for (int i = users.size() - 1; i >= 0; i--) {
+      if (userSet.contains(users.get(i))) {
+        users.remove(i);
+      }
+    }
+
+    persistentStorageAgent.deleteEntities(ids);
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -70,6 +70,7 @@ public class PersistentDataStore {
         String passwordHash = (String) entity.getProperty("password_hash");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         User user = new User(uuid, userName, passwordHash, creationTime);
+        user.setAdminStatus(Boolean.parseBoolean((String) entity.getProperty("isAdmin")));
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -158,6 +159,7 @@ public class PersistentDataStore {
     userEntity.setProperty("username", user.getName());
     userEntity.setProperty("password_hash", user.getPasswordHash());
     userEntity.setProperty("creation_time", user.getCreationTime().toString());
+    userEntity.setProperty("isAdmin", String.valueOf(user.isAdmin()));
     datastore.put(userEntity);
   }
 
@@ -182,7 +184,4 @@ public class PersistentDataStore {
     datastore.put(conversationEntity);
   }
 
-  public void delete(Key key) {
-    datastore.delete(key);
-  }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -14,20 +14,22 @@
 
 package codeu.model.store.persistence;
 
-import codeu.model.data.Conversation;
-import codeu.model.data.Message;
-import codeu.model.data.User;
-import codeu.model.store.persistence.PersistentDataStoreException;
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
 
 /**
  * This class handles all interactions with Google App Engine's Datastore service. On startup it
@@ -179,5 +181,8 @@ public class PersistentDataStore {
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
     datastore.put(conversationEntity);
   }
-}
 
+  public void delete(Key key) {
+    datastore.delete(key);
+  }
+}

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -109,19 +109,4 @@ public class PersistentStorageAgent {
     persistentDataStore.writeThrough(message);
   }
 
-  public void deleteEntity(UUID id) {
-    //Key key = KeyFactory.generateKey(id.toString());
-    //persistentDataStore.deleteEntity(key);
-  }
-
-  public void deleteEntities(List<UUID> ids) {
-    List<Key> keys = new ArrayList<Key>();
-
-    Key key;
-    for (UUID id : ids) {
-      //key = KeyFactory.generateKey(id.toString());
-      //keys.add(key);
-    }
-    //persistentDataStore.deleteEntities(keys);
-  }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -14,11 +14,16 @@
 
 package codeu.model.store.persistence;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
-import codeu.model.store.persistence.PersistentDataStore;
-import java.util.List;
 
 /**
  * This class is the interface between the application and PersistentDataStore, which handles
@@ -102,5 +107,21 @@ public class PersistentStorageAgent {
   /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
+  }
+
+  public void deleteEntity(UUID id) {
+    //Key key = KeyFactory.generateKey(id.toString());
+    //persistentDataStore.deleteEntity(key);
+  }
+
+  public void deleteEntities(List<UUID> ids) {
+    List<Key> keys = new ArrayList<Key>();
+
+    Key key;
+    for (UUID id : ids) {
+      //key = KeyFactory.generateKey(id.toString());
+      //keys.add(key);
+    }
+    //persistentDataStore.deleteEntities(keys);
   }
 }

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -10,6 +10,7 @@
 </head>
 
 <body>
+
   <nav>
     <a id="navTitle" href="/">CodeU Chat App</a>
     <a href="/conversations">Conversations</a>
@@ -26,7 +27,33 @@
     <h1>Administration
     </h1>
 
-    <button> Add Test Data </button>
+    <button id="testDataButton" onclick="testDataButtonPressed()">Add Test Data</button>
+    <form id="dataGenOptions" style="display:none" action="admin" method="POST">
+      Number of test users: <input type="number" name="numUsers"><br>
+      Number of test conversations: <input type="number" name="numConvos"><br>
+      Number of test messages: <input type="number" name="numMessages"><br>
+      <input type="submit" value="Submit">
+    </form>
+
+    <script>
+      var dataGenOptionsShown = false;
+      function testDataButtonPressed() {
+        console.log(dataGenOptionsShown);
+        let button = document.getElementById("testDataButton");
+        let options = document.getElementById("dataGenOptions");
+
+        if (dataGenOptionsShown) {
+          options.style.display = "none";
+          button.innerHTML = "Add Test Data"
+        } else {
+          options.style.display = "block";
+          button.innerHTML = "Hide"
+        }
+
+        dataGenOptionsShown = !dataGenOptionsShown;
+      }
+
+    </script>
 
     <h3>Users</h3>
       <p>Number of users: <%= request.getAttribute("numberOfUsers") %></p>
@@ -45,6 +72,7 @@
       <p>~coming soon~</p>
       <button>Submit</button>
   </div>
+
 
 </body>
 

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -23,7 +23,10 @@
   </nav>
 
   <div id="container">
-    <h1>Administration</h1>
+    <h1>Administration
+    </h1>
+
+    <button> Add Test Data </button>
 
     <h3>Users</h3>
       <p>Number of users: <%= request.getAttribute("numberOfUsers") %></p>

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -29,10 +29,15 @@
 
     <button id="testDataButton" onclick="testDataButtonPressed()">Add Test Data</button>
     <form id="dataGenOptions" style="display:none" action="admin" method="POST">
-      Number of test users: <input type="number" name="numUsers"><br>
-      Number of test conversations: <input type="number" name="numConvos"><br>
-      Number of test messages: <input type="number" name="numMessages"><br>
-      <input type="submit" value="Submit">
+      <input type="hidden" name="id" value="dataGenOptions">
+      Number of test users: <input type="number" name="numUsers" value=0><br>
+      Number of test conversations: <input type="number" name="numConvos" value=0><br>
+      Number of test messages: <input type="number" name="numMessages" value=0><br>
+      <button type="submit">Submit</button>
+    </form>
+    <form id="clearTestData" action="admin" method="POST">
+      <input type="hidden" name="id" value="clearTestData">
+      <button type="submit">Clear all test data</button>
     </form>
 
     <script>

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -40,7 +40,6 @@ public class AdminServletTest {
   @Before
   public void setup() {
     adminServlet = new AdminServlet();
-    adminServlet.setAdminUsernames();
 
     setUpStores();
 
@@ -70,7 +69,7 @@ public class AdminServletTest {
 
   @Test
   public void testDoGet_NonAdmin() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("not an admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(false);
 
     adminServlet.doGet(mockRequest, mockResponse);
 
@@ -79,7 +78,7 @@ public class AdminServletTest {
 
   @Test
   public void testDoGet_Admin() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     adminServlet.doGet(mockRequest, mockResponse);
 
@@ -89,7 +88,7 @@ public class AdminServletTest {
   // Number of users tests
   @Test
   public void testNumberOfUsers_NoUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<User> mockAllUsers = new ArrayList<User>();
 
@@ -103,7 +102,7 @@ public class AdminServletTest {
 
   @Test
   public void testNumberOfUsers_MultipleUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     User u1 = new User(UUID.randomUUID(), "user1", "hashed_pw", Instant.now());
     User u2 = new User(UUID.randomUUID(), "user2", "hashed_pw", Instant.now());
@@ -124,7 +123,7 @@ public class AdminServletTest {
   // Newest user tests
   @Test
   public void testNewestUser_NoUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<User> mockAllUsers = new ArrayList<User>();
     Mockito.when(mockUserStore.getAllUsers()).thenReturn(mockAllUsers);
@@ -136,7 +135,7 @@ public class AdminServletTest {
 
   @Test
   public void testNewestUser_MultipleUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     User u1 = new User(UUID.randomUUID(), "user1", "hashed_pw", Instant.ofEpochSecond(200));
     User u2 = new User(UUID.randomUUID(), "user2", "hashed_pw", Instant.ofEpochSecond(300));
@@ -157,7 +156,7 @@ public class AdminServletTest {
   // Most active user tests
   @Test
   public void testMostActiveUser_NoUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<User> mockAllUsers = new ArrayList<User>();
     Mockito.when(mockUserStore.getAllUsers()).thenReturn(mockAllUsers);
@@ -169,7 +168,7 @@ public class AdminServletTest {
 
   @Test
   public void testMostActiveUser_MultipleUsers() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     // Set up mock users
     User u1 = new User(UUID.randomUUID(), "user1", "hashed_pw", Instant.now());
@@ -222,7 +221,7 @@ public class AdminServletTest {
   // Number of conversations test
   @Test
   public void testNumberOfConversations_NoConversations() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
 
@@ -235,7 +234,7 @@ public class AdminServletTest {
 
   @Test
   public void testNumberOfConversations_MultipleConversations() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     UUID mockUserID = UUID.randomUUID();
@@ -255,7 +254,7 @@ public class AdminServletTest {
   // Number of messages tests
   @Test
   public void testNumberOfMessages_NoConversations() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(mockAllConversations);
@@ -267,7 +266,7 @@ public class AdminServletTest {
 
   @Test
   public void testNumberOfMessages_NoMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Conversation emptyConversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "empty conversation", Instant.now());
@@ -285,7 +284,7 @@ public class AdminServletTest {
 
   @Test
   public void testNumberOfMessages_MultipleMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     UUID mockUserID = UUID.randomUUID();
@@ -323,7 +322,7 @@ public class AdminServletTest {
   // Average messages per conversation tests
   @Test
   public void testAvgMessagesPerConvo_NoConvos() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(mockAllConversations);
@@ -335,7 +334,7 @@ public class AdminServletTest {
 
   @Test
   public void testAvgMessagesPerConvo_NoMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Conversation emptyConversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "empty conversation", Instant.now());
@@ -354,7 +353,7 @@ public class AdminServletTest {
 
   @Test
   public void testAvgMessagesPerConvo_MultipleMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     UUID mockUserID = UUID.randomUUID();
@@ -397,7 +396,7 @@ public class AdminServletTest {
   // Average words per message tests
   @Test
   public void testAvgWordsPerMessage_NoConvos() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(mockAllConversations);
@@ -411,7 +410,7 @@ public class AdminServletTest {
 
   @Test
   public void testAvgWordsPerMessage_NoMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     Conversation emptyConversation = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "empty conversation", Instant.now());
@@ -430,7 +429,7 @@ public class AdminServletTest {
 
   @Test
   public void testAvgWordsPerMessage_MultipleMessages() throws IOException, ServletException {
-    Mockito.when(mockSession.getAttribute("user")).thenReturn("admin");
+    Mockito.when(mockSession.getAttribute("isAdmin")).thenReturn(true);
 
     List<Conversation> mockAllConversations = new ArrayList<Conversation>();
     UUID mockUserID = UUID.randomUUID();

--- a/src/test/java/codeu/controller/TestDataGeneratorTest.java
+++ b/src/test/java/codeu/controller/TestDataGeneratorTest.java
@@ -1,0 +1,168 @@
+package codeu.controller;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import codeu.model.data.Conversation;
+import codeu.model.data.Message;
+import codeu.model.data.User;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.basic.MessageStore;
+import codeu.model.store.basic.UserStore;
+import codeu.model.store.persistence.PersistentDataStoreException;
+import codeu.model.store.persistence.PersistentStorageAgent;
+
+public class TestDataGeneratorTest {
+
+  private PersistentStorageAgent mockPersistentStorageAgent;
+  private TestDataGenerator mockTestDataGenerator;
+
+  private UserStore mockUserStore;
+  private ConversationStore mockConversationStore;
+  private MessageStore mockMessageStore;
+
+  @Before
+  public void setup() throws PersistentDataStoreException {
+
+    mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
+    Mockito.when(mockPersistentStorageAgent.loadUsers()).thenReturn(new ArrayList<User>());
+    Mockito.when(mockPersistentStorageAgent.loadConversations()).thenReturn(new ArrayList<Conversation>());
+    Mockito.when(mockPersistentStorageAgent.loadMessages()).thenReturn(new ArrayList<Message>());
+
+    mockTestDataGenerator = TestDataGenerator.getTestInstance(mockPersistentStorageAgent);
+
+    setUpStores();
+  }
+
+  void setUpStores() {
+
+    mockUserStore = UserStore.getTestInstance(mockPersistentStorageAgent);
+    mockTestDataGenerator.setUserStore(mockUserStore);
+
+    mockConversationStore = ConversationStore.getTestInstance(mockPersistentStorageAgent);
+    mockTestDataGenerator.setConversationStore(mockConversationStore);
+
+    mockMessageStore = MessageStore.getTestInstance(mockPersistentStorageAgent);
+    mockTestDataGenerator.setMessageStore(mockMessageStore);
+
+  }
+
+  @Test
+  public void testAddTestUsers() {
+
+    int numUsersBefore = mockUserStore.getAllUsers().size();
+
+    mockTestDataGenerator.addTestUsers(3);
+
+    int numUsersAfter = mockUserStore.getAllUsers().size();
+
+    assertEquals(numUsersBefore + 3, numUsersAfter);
+
+  }
+
+  @Test
+  public void testAddTestConversations_NoTestUsers() {
+
+    int numConversationsBefore = mockConversationStore.getAllConversations().size();
+
+    mockTestDataGenerator.addTestConversations(3);
+
+    int numConversationsAfter = mockConversationStore.getAllConversations().size();
+
+    assertEquals(numConversationsBefore, numConversationsAfter);
+
+  }
+
+  @Test
+  public void testAddTestConversations() {
+
+    int numConversationsBefore = mockConversationStore.getAllConversations().size();
+
+    mockTestDataGenerator.addTestUsers(3);
+    mockTestDataGenerator.addTestConversations(3);
+
+    int numConversationsAfter = mockConversationStore.getAllConversations().size();
+
+    assertEquals(numConversationsBefore + 3, numConversationsAfter);
+
+  }
+
+  @Test
+  public void testAddTestMessages_NoTestUsers() {
+
+    int numMessagesBefore = mockMessageStore.getAllMessages().size();
+
+    mockTestDataGenerator.addTestMessages(3);
+
+    int numMessagesAfter = mockMessageStore.getAllMessages().size();
+
+    assertEquals(numMessagesBefore, numMessagesAfter);
+
+  }
+
+  @Test
+  public void testAddTestMessages_NoTestConversations() {
+
+    int numMessagesBefore = mockMessageStore.getAllMessages().size();
+
+    mockTestDataGenerator.addTestUsers(3);
+    mockTestDataGenerator.addTestMessages(3);
+
+    int numMessagesAfter = mockMessageStore.getAllMessages().size();
+
+    assertEquals(numMessagesBefore, numMessagesAfter);
+
+  }
+
+  @Test
+  public void testAddTestMessages() {
+
+    int numMessagesBefore = mockMessageStore.getAllMessages().size();
+
+    mockTestDataGenerator.addTestUsers(3);
+    mockTestDataGenerator.addTestConversations(3);
+    mockTestDataGenerator.addTestMessages(3);
+
+    int numMessagesAfter = mockMessageStore.getAllMessages().size();
+
+    assertEquals(numMessagesBefore + 3, numMessagesAfter);
+
+  }
+
+  @Test
+  public void testClearTestData() {
+
+    int numUsersBefore = mockUserStore.getAllUsers().size();
+    int numConversationsBefore = mockConversationStore.getAllConversations().size();
+    int numMessagesBefore = mockMessageStore.getAllMessages().size();
+
+    mockTestDataGenerator.addTestUsers(3);
+    mockTestDataGenerator.addTestConversations(3);
+    mockTestDataGenerator.addTestMessages(3);
+
+    int numUsersAfter = mockUserStore.getAllUsers().size();
+    int numConversationsAfter = mockConversationStore.getAllConversations().size();
+    int numMessagesAfter = mockMessageStore.getAllMessages().size();
+
+    assertEquals(numUsersBefore + 3, numUsersAfter);
+    assertEquals(numConversationsBefore + 3, numConversationsAfter);
+    assertEquals(numMessagesBefore + 3, numMessagesAfter);
+
+    mockTestDataGenerator.clearTestData();
+
+    int numUsersAfterClear = mockUserStore.getAllUsers().size();
+    int numConversationsAfterClear = mockConversationStore.getAllConversations().size();
+    int numMessagesAfterClear = mockMessageStore.getAllMessages().size();
+
+    assertEquals(0, numUsersAfterClear);
+    assertEquals(0, numConversationsAfterClear);
+    assertEquals(0, numMessagesAfterClear);
+
+  }
+
+}

--- a/src/test/java/codeu/controller/TestDataGeneratorTest.java
+++ b/src/test/java/codeu/controller/TestDataGeneratorTest.java
@@ -55,74 +55,62 @@ public class TestDataGeneratorTest {
   @Test
   public void testAddTestUsers() {
 
-    int numUsersBefore = mockUserStore.getAllUsers().size();
-
     mockTestDataGenerator.addTestUsers(3);
 
     int numUsersAfter = mockUserStore.getAllUsers().size();
 
-    assertEquals(numUsersBefore + 3, numUsersAfter);
+    assertEquals(3, numUsersAfter);
 
   }
 
   @Test
   public void testAddTestConversations_NoTestUsers() {
 
-    int numConversationsBefore = mockConversationStore.getAllConversations().size();
-
     mockTestDataGenerator.addTestConversations(3);
 
     int numConversationsAfter = mockConversationStore.getAllConversations().size();
 
-    assertEquals(numConversationsBefore, numConversationsAfter);
+    assertEquals(0, numConversationsAfter);
 
   }
 
   @Test
   public void testAddTestConversations() {
 
-    int numConversationsBefore = mockConversationStore.getAllConversations().size();
-
     mockTestDataGenerator.addTestUsers(3);
     mockTestDataGenerator.addTestConversations(3);
 
     int numConversationsAfter = mockConversationStore.getAllConversations().size();
 
-    assertEquals(numConversationsBefore + 3, numConversationsAfter);
+    assertEquals(3, numConversationsAfter);
 
   }
 
   @Test
   public void testAddTestMessages_NoTestUsers() {
 
-    int numMessagesBefore = mockMessageStore.getAllMessages().size();
-
     mockTestDataGenerator.addTestMessages(3);
 
     int numMessagesAfter = mockMessageStore.getAllMessages().size();
 
-    assertEquals(numMessagesBefore, numMessagesAfter);
+    assertEquals(0, numMessagesAfter);
 
   }
 
   @Test
   public void testAddTestMessages_NoTestConversations() {
 
-    int numMessagesBefore = mockMessageStore.getAllMessages().size();
-
     mockTestDataGenerator.addTestUsers(3);
     mockTestDataGenerator.addTestMessages(3);
 
     int numMessagesAfter = mockMessageStore.getAllMessages().size();
 
-    assertEquals(numMessagesBefore, numMessagesAfter);
+    assertEquals(0, numMessagesAfter);
 
   }
 
   @Test
   public void testAddTestMessages() {
-
-    int numMessagesBefore = mockMessageStore.getAllMessages().size();
 
     mockTestDataGenerator.addTestUsers(3);
     mockTestDataGenerator.addTestConversations(3);
@@ -130,16 +118,12 @@ public class TestDataGeneratorTest {
 
     int numMessagesAfter = mockMessageStore.getAllMessages().size();
 
-    assertEquals(numMessagesBefore + 3, numMessagesAfter);
+    assertEquals(3, numMessagesAfter);
 
   }
 
   @Test
   public void testClearTestData() {
-
-    int numUsersBefore = mockUserStore.getAllUsers().size();
-    int numConversationsBefore = mockConversationStore.getAllConversations().size();
-    int numMessagesBefore = mockMessageStore.getAllMessages().size();
 
     mockTestDataGenerator.addTestUsers(3);
     mockTestDataGenerator.addTestConversations(3);
@@ -149,9 +133,9 @@ public class TestDataGeneratorTest {
     int numConversationsAfter = mockConversationStore.getAllConversations().size();
     int numMessagesAfter = mockMessageStore.getAllMessages().size();
 
-    assertEquals(numUsersBefore + 3, numUsersAfter);
-    assertEquals(numConversationsBefore + 3, numConversationsAfter);
-    assertEquals(numMessagesBefore + 3, numMessagesAfter);
+    assertEquals(3, numUsersAfter);
+    assertEquals(3, numConversationsAfter);
+    assertEquals(3, numMessagesAfter);
 
     mockTestDataGenerator.clearTestData();
 


### PR DESCRIPTION
On the admin page, an admin can specify a number of fake users, conversations, and messages to add to the site. These entities appear in the conversation page and in the site statistics. The admin can manually clear all the generated test data, but all test data gets removed anyway when the server restarts, as it is never actually written to the datastore.