### PR TITLE
Allowed for any image type to be uploaded.

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -201,7 +201,7 @@ public class ChatServlet extends HttpServlet {
 
 				// Set the content of the message to an img tag that calls the ImageServlet
 				String src = "/image/" + imageAttachment.getId().toString();
-				String content = "<img src=" + src + " width=500>";
+				String content = "<a href=" + src + "><img src=" + src + " width=200></a>";
 				Message message = new Message(UUID.randomUUID(), conversation.getId(),
 						user.getId(), content, Instant.now());
 

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -193,8 +193,11 @@ public class ChatServlet extends HttpServlet {
 				// Convert bytestream into BufferedImage object
 				BufferedImage image = ImageIO.read(fileStream);
 
+				String contentType = filePart.getContentType();
+				String imageType = contentType.substring(contentType.lastIndexOf("/")+1);
+
 				// Create image attachment object from BufferedImage object
-				ImageAttachment imageAttachment = new ImageAttachment(UUID.randomUUID(), image);
+				ImageAttachment imageAttachment = new ImageAttachment(UUID.randomUUID(), image, imageType);
 
 				// Set the content of the message to an img tag that calls the ImageServlet
 				String src = "/image/" + imageAttachment.getId().toString();

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -193,20 +193,23 @@ public class ChatServlet extends HttpServlet {
 				// Convert bytestream into BufferedImage object
 				BufferedImage image = ImageIO.read(fileStream);
 
-				String contentType = filePart.getContentType();
-				String imageType = contentType.substring(contentType.lastIndexOf("/")+1);
+				// Check that the file was actually an image
+				if (image != null) {
+					String contentType = filePart.getContentType();
+					String imageType = contentType.substring(contentType.lastIndexOf("/")+1);
 
-				// Create image attachment object from BufferedImage object
-				ImageAttachment imageAttachment = new ImageAttachment(UUID.randomUUID(), image, imageType);
+					// Create image attachment object from BufferedImage object
+					ImageAttachment imageAttachment = new ImageAttachment(UUID.randomUUID(), image, imageType);
 
-				// Set the content of the message to an img tag that calls the ImageServlet
-				String src = "/image/" + imageAttachment.getId().toString();
-				String content = "<a href=" + src + "><img src=" + src + " width=200></a>";
-				Message message = new Message(UUID.randomUUID(), conversation.getId(),
-						user.getId(), content, Instant.now());
+					// Set the content of the message to an img tag that calls the ImageServlet
+					String src = "/image/" + imageAttachment.getId().toString();
+					String content = "<a href=" + src + "><img src=" + src + " width=200></a>";
+					Message message = new Message(UUID.randomUUID(), conversation.getId(),
+							user.getId(), content, Instant.now());
 
-				messageStore.addMessage(message);
-				imageStore.addImage(imageAttachment);
+					messageStore.addMessage(message);
+					imageStore.addImage(imageAttachment);
+				}
 			}
 		}
 		// redirect to a GET request

--- a/src/main/java/codeu/controller/ImageServlet.java
+++ b/src/main/java/codeu/controller/ImageServlet.java
@@ -44,14 +44,14 @@ public class ImageServlet extends HttpServlet {
       System.out.println("No image found with id: " + imageId);
       return;
     }
-    
+
     BufferedImage image = imageAttachment.getImage();
-    response.setContentType("image/png");
+    response.setContentType("image/" + imageAttachment.getImageType());
 
     // Write the bytes of the image to the response
     try {
       OutputStream out = response.getOutputStream();
-      ImageIO.write(image, "png", out);
+      ImageIO.write(image, imageAttachment.getImageType(), out);
       out.close();
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/codeu/controller/ImageServlet.java
+++ b/src/main/java/codeu/controller/ImageServlet.java
@@ -41,7 +41,6 @@ public class ImageServlet extends HttpServlet {
     ImageAttachment imageAttachment = imageStore.getImage(imageUUID);
 
     if (imageAttachment == null) {
-      System.out.println("No image found with id: " + imageId);
       return;
     }
 

--- a/src/main/java/codeu/model/data/ImageAttachment.java
+++ b/src/main/java/codeu/model/data/ImageAttachment.java
@@ -16,9 +16,12 @@ public class ImageAttachment {
 
   private UUID id;
 
-  public ImageAttachment(UUID id, BufferedImage image) {
+  private String imageType;
+
+  public ImageAttachment(UUID id, BufferedImage image, String imageType) {
     this.image = image;
     this.id = id;
+    this.imageType = imageType;
   }
 
   public ImageAttachment(UUID id, String base64String) {
@@ -37,6 +40,10 @@ public class ImageAttachment {
     return id;
   }
 
+  public String getImageType() {
+    return imageType;
+  }
+
   /**
    * Converts a String containing the bytes of an image into a BufferedImage object
    */
@@ -48,13 +55,13 @@ public class ImageAttachment {
   }
 
   /**
-   * Converts the BufferedImage object of this object into a String, given an image format
+   * Converts the BufferedImage object of this object into a String
    */
-  public String getBase64String(String format) {
+  public String getBase64String() {
 	  ByteArrayOutputStream os = new ByteArrayOutputStream();
 
 	  try {
-	    ImageIO.write(image, format, os);
+	    ImageIO.write(image, imageType, os);
 	    return Base64.getEncoder().encodeToString(os.toByteArray());
 	  }
 	  catch (IOException ioe) {

--- a/src/main/java/codeu/model/data/ImageAttachment.java
+++ b/src/main/java/codeu/model/data/ImageAttachment.java
@@ -24,12 +24,13 @@ public class ImageAttachment {
     this.imageType = imageType;
   }
 
-  public ImageAttachment(UUID id, String base64String) {
+  public ImageAttachment(UUID id, String base64String, String imageType) {
     try {
       this.image = getImageFromString(base64String);
     } catch (IOException e) {}
 
     this.id = id;
+    this.imageType = imageType;
   }
 
   public BufferedImage getImage() {

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -26,6 +26,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Text;
+import com.google.apphosting.api.ApiProxy.RequestTooLargeException;
 
 import codeu.model.data.Conversation;
 import codeu.model.data.ImageAttachment;
@@ -250,9 +251,13 @@ public class PersistentDataStore {
     Entity imageEntity = new Entity("chat-images", image.getId().toString());
     imageEntity.setProperty("uuid", image.getId().toString());
 
-    Text imageBytes = new Text(image.getBase64String("png"));
+    Text imageBytes = new Text(image.getBase64String());
     imageEntity.setProperty("image_bytes", imageBytes);
 
-    datastore.put(imageEntity);
+    try {
+      datastore.put(imageEntity);
+    } catch (RequestTooLargeException e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -192,8 +192,9 @@ public class PersistentDataStore {
       try {
         UUID uuid = UUID.fromString((String) entity.getProperty("uuid"));
         String imageBytes = ((Text) entity.getProperty("image_bytes")).getValue();
+        String imageType = (String) entity.getProperty("image_type");
 
-        ImageAttachment image = new ImageAttachment(uuid, imageBytes);
+        ImageAttachment image = new ImageAttachment(uuid, imageBytes, imageType);
         images.add(image);
       } catch (Exception e) {
         e.printStackTrace();
@@ -253,6 +254,9 @@ public class PersistentDataStore {
 
     Text imageBytes = new Text(image.getBase64String());
     imageEntity.setProperty("image_bytes", imageBytes);
+
+    String imageType = image.getImageType();
+    imageEntity.setProperty("image_type", imageType);
 
     try {
       datastore.put(imageEntity);


### PR DESCRIPTION
Originally, I had it hardcoded to read/write the images as PNGs. It didn't seem to cause any problems, so I left it in. But after playing around with it for a little bit, I realized that uploading JPG files that were much less than 1MB became larger than 1MB when reading them as PNGs. I implemented a feature that reads the file extension of the image the user uploads, and treats it accordingly.